### PR TITLE
Add bilingual navigation and French landing page

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ATPERF - Take control of your system's performance</title>
+    <title>ATPERF - Maîtrisez les performances de votre système</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -13,30 +13,30 @@
         <nav class="navbar">
             <div class="nav-container">
                 <div class="nav-logo">
-                    <img src="Atperf_Logo.png" alt="ATPERF Logo">
+                    <img src="Atperf_Logo.png" alt="Logo ATPERF">
                 </div>
                 <ul class="nav-menu">
                     <li class="nav-item">
-                        <a href="#home" class="nav-link active">Home</a>
+                        <a href="#home" class="nav-link active">Accueil</a>
                     </li>
                     <li class="nav-item">
-                        <a href="#service" class="nav-link">Service</a>
+                        <a href="#service" class="nav-link">Services</a>
                     </li>
                     <li class="nav-item">
-                        <a href="#usecase" class="nav-link">Use case</a>
+                        <a href="#usecase" class="nav-link">Cas d'usage</a>
                     </li>
                     <li class="nav-item">
                         <a href="#contact" class="nav-link">Contact</a>
                     </li>
                     <li class="nav-item language-switcher">
-                        <a href="index.html" class="language-link active" lang="en" aria-current="page">EN</a>
+                        <a href="index.html" class="language-link" lang="en">EN</a>
                         <span class="language-separator" aria-hidden="true">/</span>
-                        <a href="index-fr.html" class="language-link" lang="fr">FR</a>
+                        <a href="index-fr.html" class="language-link active" lang="fr" aria-current="page">FR</a>
                     </li>
                 </ul>
                 <div class="nav-buttons">
-                    <button class="btn btn-outline">Sign Up</button>
-                    <button class="btn btn-primary">Contact Us</button>
+                    <button class="btn btn-outline">Inscription</button>
+                    <button class="btn btn-primary">Contactez-nous</button>
                     <button class="btn btn-test">Tester notre outil</button>
                 </div>
                 <div class="hamburger">
@@ -54,15 +54,15 @@
             <div class="hero-content">
                 <div class="hero-text">
                     <h1 class="hero-title">
-                        Take control of your 
-                        <span class="highlight">system's performance</span>
+                        Maîtrisez les
+                        <span class="highlight">performances de votre système</span>
                     </h1>
                     <p class="hero-description">
-                        Optimize your infrastructure with our advanced performance monitoring and analytics platform. 
-                        Get real-time insights and actionable recommendations to boost your system efficiency.
+                        Optimisez votre infrastructure grâce à notre plateforme avancée de surveillance et d'analytique des performances.
+                        Obtenez des informations en temps réel et des recommandations concrètes pour booster l'efficacité de vos systèmes.
                     </p>
                     <div class="hero-buttons">
-                        <button class="btn btn-primary btn-large">Get Started</button>
+                        <button class="btn btn-primary btn-large">Commencer</button>
                         <button class="btn btn-test btn-large">Tester notre outil</button>
                     </div>
                 </div>
@@ -88,32 +88,32 @@
     <section id="service" class="services">
         <div class="container">
             <div class="section-header">
-                <h2 class="section-title">Our Services</h2>
-                <p class="section-description">Comprehensive performance solutions for your business</p>
+                <h2 class="section-title">Nos services</h2>
+                <p class="section-description">Des solutions de performance complètes pour votre entreprise</p>
             </div>
             <div class="services-grid">
                 <div class="service-card">
                     <div class="service-icon">
                         <div class="icon-circle">📊</div>
                     </div>
-                    <h3 class="service-title">Performance Monitoring</h3>
-                    <p class="service-description">Real-time monitoring of your system's performance metrics with detailed analytics and reporting.</p>
+                    <h3 class="service-title">Surveillance des performances</h3>
+                    <p class="service-description">Suivi en temps réel de vos indicateurs clés avec analyses détaillées et rapports personnalisés.</p>
                     <button class="btn btn-test">Tester notre outil</button>
                 </div>
                 <div class="service-card">
                     <div class="service-icon">
                         <div class="icon-circle">⚡</div>
                     </div>
-                    <h3 class="service-title">System Optimization</h3>
-                    <p class="service-description">Advanced algorithms to optimize your infrastructure and improve overall system efficiency.</p>
+                    <h3 class="service-title">Optimisation du système</h3>
+                    <p class="service-description">Algorithmes avancés pour optimiser votre infrastructure et améliorer l'efficacité globale.</p>
                     <button class="btn btn-test">Tester notre outil</button>
                 </div>
                 <div class="service-card">
                     <div class="service-icon">
                         <div class="icon-circle">🔍</div>
                     </div>
-                    <h3 class="service-title">Analytics & Insights</h3>
-                    <p class="service-description">Deep insights into your system's behavior with predictive analytics and recommendations.</p>
+                    <h3 class="service-title">Analyses et insights</h3>
+                    <p class="service-description">Des insights approfondis sur le comportement de vos systèmes avec des recommandations prédictives.</p>
                     <button class="btn btn-test">Tester notre outil</button>
                 </div>
             </div>
@@ -124,8 +124,8 @@
     <section id="usecase" class="use-cases">
         <div class="container">
             <div class="section-header">
-                <h2 class="section-title">Use Cases</h2>
-                <p class="section-description">See how ATPERF transforms businesses across industries</p>
+                <h2 class="section-title">Cas d'usage</h2>
+                <p class="section-description">Découvrez comment ATPERF transforme les entreprises de tous secteurs</p>
             </div>
             <div class="use-cases-grid">
                 <div class="use-case-card">
@@ -133,8 +133,8 @@
                         <div class="placeholder-image">🏢</div>
                     </div>
                     <div class="use-case-content">
-                        <h3 class="use-case-title">Enterprise Solutions</h3>
-                        <p class="use-case-description">Large-scale performance optimization for enterprise infrastructure and applications.</p>
+                        <h3 class="use-case-title">Solutions pour grandes entreprises</h3>
+                        <p class="use-case-description">Optimisation à grande échelle pour les infrastructures et applications critiques.</p>
                         <button class="btn btn-test">Tester notre outil</button>
                     </div>
                 </div>
@@ -143,8 +143,8 @@
                         <div class="placeholder-image">☁️</div>
                     </div>
                     <div class="use-case-content">
-                        <h3 class="use-case-title">Cloud Infrastructure</h3>
-                        <p class="use-case-description">Optimize cloud resources and reduce costs while maintaining peak performance.</p>
+                        <h3 class="use-case-title">Infrastructure cloud</h3>
+                        <p class="use-case-description">Optimisez vos ressources cloud et réduisez les coûts tout en maintenant des performances optimales.</p>
                         <button class="btn btn-test">Tester notre outil</button>
                     </div>
                 </div>
@@ -153,8 +153,8 @@
                         <div class="placeholder-image">🚀</div>
                     </div>
                     <div class="use-case-content">
-                        <h3 class="use-case-title">Startups & SMEs</h3>
-                        <p class="use-case-description">Scalable performance solutions designed for growing businesses and startups.</p>
+                        <h3 class="use-case-title">Startups & PME</h3>
+                        <p class="use-case-description">Des solutions de performance évolutives conçues pour accompagner votre croissance.</p>
                         <button class="btn btn-test">Tester notre outil</button>
                     </div>
                 </div>
@@ -167,8 +167,8 @@
         <div class="container">
             <div class="contact-content">
                 <div class="contact-info">
-                    <h2 class="section-title">Get in Touch</h2>
-                    <p class="section-description">Ready to optimize your system's performance? Contact us today.</p>
+                    <h2 class="section-title">Entrer en contact</h2>
+                    <p class="section-description">Prêt à optimiser les performances de votre système ? Contactez-nous dès aujourd'hui.</p>
                     <div class="contact-details">
                         <div class="contact-item">
                             <span class="contact-icon">📧</span>
@@ -188,18 +188,18 @@
                 <div class="contact-form">
                     <form class="form">
                         <div class="form-group">
-                            <input type="text" class="form-input" name="fullName" placeholder="Your Name" required>
+                            <input type="text" class="form-input" name="fullName" placeholder="Votre nom" required>
                         </div>
                         <div class="form-group">
-                            <input type="email" class="form-input" name="email" placeholder="Your Email" required>
+                            <input type="email" class="form-input" name="email" placeholder="Votre email" required>
                         </div>
                         <div class="form-group">
-                            <input type="text" class="form-input" name="subject" placeholder="Subject" required>
+                            <input type="text" class="form-input" name="subject" placeholder="Objet" required>
                         </div>
                         <div class="form-group">
-                            <textarea class="form-input form-textarea" name="message" placeholder="Your Message" rows="5" required></textarea>
+                            <textarea class="form-input form-textarea" name="message" placeholder="Votre message" rows="5" required></textarea>
                         </div>
-                        <button type="submit" class="btn btn-primary btn-large">Send Message</button>
+                        <button type="submit" class="btn btn-primary btn-large">Envoyer le message</button>
                     </form>
                 </div>
             </div>
@@ -211,28 +211,28 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <img src="Atperf_Logo.png" alt="ATPERF Logo">
-                    <p>Take control of your system's performance</p>
+                    <img src="Atperf_Logo.png" alt="Logo ATPERF">
+                    <p>Maîtrisez les performances de votre système</p>
                 </div>
                 <div class="footer-links">
                     <div class="footer-column">
                         <h4>Services</h4>
                         <ul>
-                            <li><a href="#service">Performance Monitoring</a></li>
-                            <li><a href="#service">System Optimization</a></li>
-                            <li><a href="#service">Analytics & Insights</a></li>
+                            <li><a href="#service">Surveillance des performances</a></li>
+                            <li><a href="#service">Optimisation du système</a></li>
+                            <li><a href="#service">Analyses & Insights</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
-                        <h4>Company</h4>
+                        <h4>Entreprise</h4>
                         <ul>
-                            <li><a href="#home">About Us</a></li>
+                            <li><a href="#home">À propos</a></li>
                             <li><a href="#contact">Contact</a></li>
-                            <li><a href="#usecase">Use Cases</a></li>
+                            <li><a href="#usecase">Cas d'usage</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
-                        <h4>Tools</h4>
+                        <h4>Outils</h4>
                         <ul>
                             <li><a href="#" class="test-tool-link">Tester notre outil</a></li>
                             <li><a href="#">Documentation</a></li>
@@ -242,7 +242,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 ATPERF. All rights reserved.</p>
+                <p>&copy; 2024 ATPERF. Tous droits réservés.</p>
             </div>
         </div>
     </footer>

--- a/script.js
+++ b/script.js
@@ -21,7 +21,8 @@ function initMobileMenu() {
         });
 
         // Close menu when clicking on nav links
-        document.querySelectorAll('.nav-link').forEach(link => {
+        const menuLinks = document.querySelectorAll('.nav-link, .language-link');
+        menuLinks.forEach(link => {
             link.addEventListener('click', function() {
                 hamburger.classList.remove('active');
                 navMenu.classList.remove('active');
@@ -42,9 +43,26 @@ function initMobileMenu() {
 function initSmoothScrolling() {
     document.querySelectorAll('a[href^="#"]').forEach(anchor => {
         anchor.addEventListener('click', function(e) {
-            e.preventDefault();
-            const target = document.querySelector(this.getAttribute('href'));
+            const targetSelector = this.getAttribute('href');
+
+            if (!targetSelector) {
+                return;
+            }
+
+            if (targetSelector.trim() === '#') {
+                e.preventDefault();
+                return;
+            }
+
+            let target = null;
+            try {
+                target = document.querySelector(targetSelector);
+            } catch (error) {
+                console.warn('Invalid smooth scroll target selector:', targetSelector, error);
+            }
+
             if (target) {
+                e.preventDefault();
                 const headerOffset = 80;
                 const elementPosition = target.getBoundingClientRect().top;
                 const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
@@ -112,7 +130,7 @@ function initFormHandling() {
     if (contactForm) {
         contactForm.addEventListener('submit', function(e) {
             e.preventDefault();
-            
+
             // Get form data
             const formData = new FormData(this);
             const formObject = {};
@@ -120,15 +138,31 @@ function initFormHandling() {
                 formObject[key] = value;
             });
 
+            console.log('Form submission data:', formObject);
+
+            const locale = document.documentElement.lang || 'en';
+            const formMessages = {
+                en: {
+                    sending: 'Sending...',
+                    success: 'Message sent successfully!'
+                },
+                fr: {
+                    sending: 'Envoi...',
+                    success: 'Message envoyé avec succès !'
+                }
+            };
+
+            const messages = formMessages[locale] || formMessages.en;
+
             // Show loading state
             const submitBtn = this.querySelector('button[type="submit"]');
             const originalText = submitBtn.textContent;
-            submitBtn.textContent = 'Sending...';
+            submitBtn.textContent = messages.sending;
             submitBtn.disabled = true;
 
             // Simulate form submission (replace with actual API call)
             setTimeout(() => {
-                showNotification('Message sent successfully!', 'success');
+                showNotification(messages.success, 'success');
                 this.reset();
                 submitBtn.textContent = originalText;
                 submitBtn.disabled = false;
@@ -139,12 +173,12 @@ function initFormHandling() {
 
 // Test Tool Button Functionality
 function initTestToolButtons() {
-    const testButtons = document.querySelectorAll('.btn-test');
-    
+    const testButtons = document.querySelectorAll('.btn-test, .test-tool-link');
+
     testButtons.forEach(button => {
         button.addEventListener('click', function(e) {
             e.preventDefault();
-            
+
             // Add click animation
             this.style.transform = 'scale(0.95)';
             setTimeout(() => {

--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,30 @@ body {
     gap: 2rem;
 }
 
+.nav-item.language-switcher {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+}
+
+.language-link {
+    text-decoration: none;
+    color: #666;
+    font-weight: 600;
+    transition: color 0.3s ease;
+}
+
+.language-link:hover,
+.language-link.active {
+    color: #FF6B35;
+}
+
+.language-separator {
+    color: #ccc;
+    font-weight: 500;
+}
+
 .nav-link {
     text-decoration: none;
     color: #333;
@@ -602,6 +626,10 @@ body {
 
     .nav-buttons {
         display: none;
+    }
+
+    .nav-item.language-switcher {
+        justify-content: center;
     }
 
     .hero-content {


### PR DESCRIPTION
## Summary
- add a language toggle to the navigation and wire it to both English and French versions of the site
- create a fully localized French landing page that mirrors the existing English layout
- improve shared scripts by hardening smooth scrolling, localizing form messages, and ensuring contact data and tool links work as expected

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d10db199e0832f9f4adaf2f4b00607